### PR TITLE
chore: btn, img SVG를 iconMap에 통합 (#13)

### DIFF
--- a/app/components/SVGIcon/iconMap.ts
+++ b/app/components/SVGIcon/iconMap.ts
@@ -30,6 +30,24 @@ import ToggleIcon from "@/app/assets/icon/1/toggle.svg";
 import VisibilityOffIcon from "@/app/assets/icon/1/visibility_off.svg";
 import VisibilityOnIcon from "@/app/assets/icon/1/visibility_on.svg";
 import XIcon from "@/app/assets/icon/1/x.svg";
+import BtnArrowLeftIcon from "@/app/assets/btn/arrow-left.svg";
+import BtnArrowRightIcon from "@/app/assets/btn/arrow-right.svg";
+import BtnCalendarIcon from "@/app/assets/btn/calendar.svg";
+import BtnDatepickerDefaultIcon from "@/app/assets/btn/datepicker-default.svg";
+import BtnDatepickerOnIcon from "@/app/assets/btn/datepicker-on.svg";
+import BtnEditLargeIcon from "@/app/assets/btn/edit-large.svg";
+import BtnEditSmallIcon from "@/app/assets/btn/edit-small.svg";
+import BtnEnterActiveIcon from "@/app/assets/btn/enter-active.svg";
+import BtnEnterDefaultIcon from "@/app/assets/btn/enter-default.svg";
+import BtnRadioDefaultIcon from "@/app/assets/btn/radio-default.svg";
+import BtnRadioOnIcon from "@/app/assets/btn/radio-on.svg";
+import GoogleIcon from "@/app/assets/img/google.svg";
+import ImgDoneIcon from "@/app/assets/img/img-done.svg";
+import ImgTodoIcon from "@/app/assets/img/img-todo.svg";
+import KakaotalkIcon from "@/app/assets/img/kakaotalk.svg";
+import LogoLargeIcon from "@/app/assets/img/logo_coworkers/logo-large.svg";
+import LogoSmallIcon from "@/app/assets/img/logo_coworkers/logo-small.svg";
+import ThumbnailTeamIcon from "@/app/assets/img/thumbnail-team.svg";
 
 export const IconMap = {
   alert: AlertIcon,
@@ -64,6 +82,26 @@ export const IconMap = {
   visibilityOff: VisibilityOffIcon,
   visibilityOn: VisibilityOnIcon,
   x: XIcon,
+  // btn
+  btnArrowLeft: BtnArrowLeftIcon,
+  btnArrowRight: BtnArrowRightIcon,
+  btnCalendar: BtnCalendarIcon,
+  btnDatepickerDefault: BtnDatepickerDefaultIcon,
+  btnDatepickeron: BtnDatepickerOnIcon,
+  btnEditLarge: BtnEditLargeIcon,
+  btnEditSmall: BtnEditSmallIcon,
+  btnEnterActive: BtnEnterActiveIcon,
+  btnEnterDefault: BtnEnterDefaultIcon,
+  btnRadioDefault: BtnRadioDefaultIcon,
+  btnRadio0n: BtnRadioOnIcon,
+  // img
+  google: GoogleIcon,
+  imgDone: ImgDoneIcon,
+  imgTodo: ImgTodoIcon,
+  kakaotalk: KakaotalkIcon,
+  LogoLarge: LogoLargeIcon,
+  logoSmall: LogoSmallIcon,
+  thumbnailTeam: ThumbnailTeamIcon,
 } as const;
 
 export const IconSizes = {


### PR DESCRIPTION
## **📌 PR 개요**

- btn, img SVG 사용을 위해 iconMap에 통합하였습니다.

## **🔍 관련 이슈**

- Closes #13 

## **🔧 변경 유형**

해당하는 항목에 체크해주세요.

- [ ] ✨ feat (새 기능 추가)
- [ ] 🐛 fix (버그 수정)
- [ ] 📝 docs (문서 수정)
- [ ] 🎨 style (코드 스타일 변경)
- [ ] ♻️ refactor (리팩토링)
- [ ] ✅ test (테스트 코드)
- [x] 🛠 chore (빌드/환경설정)

## **✨ 변경 사항**

- btn, img 폴더의 SVG 파일을 iconMap에 추가

## **📝 PR 제목 규칙**

PR 제목은 커밋 컨벤션을 따라야 합니다.

ex) feat: 롤링페이퍼 작성 기능 추가 (#15)

## **✅ 체크리스트**

- [x] 코드가 정상 동작함
- [x] 빌드 및 실행 확인 완료
- [x] 리뷰어가 이해하기 쉽게 변경 이유를 설명했음

## **📸 스크린샷 (선택)**

- UI 변경이 있다면 캡처 이미지 첨부

## **🤝 기타 참고 사항**

- 개발편의상 btn,img파일도 iconMap에 작성했습니다.
btn, img SVG 파일을 별도의 buttonMap, imageMap으로 분리할지, 아니면 지금처럼 iconMap에 사용할지 얘기 나눠보면 좋을 것 같습니다.

- 분리할 경우 역할과 의미가 병확해진다는 장점이 있습니다.
```
iconMap  → UI 심볼
buttonMap → 버튼 전용 SVG
imageMap → 콘텐츠/표현용 SVG
```
또한 App Router 기준 서버와 클라이언트 경계를 더 선명히 구분할 수 있습니다. (ex. btn은 client에서만 사용, img는 서버 렌더링 유지하는 등 불필요한 use client 방지)
다만,  import 위치가 다르고 사용 방식이 다르다는 점에서 사용성이 떨어진다는 단점이 있습니다. 
디자인 명세 내에 btn과 img, icon이 다 따로 분리되어 있지만, 실제 사용할 때에는 이게 왜 icon인지 button인지 헷갈릴 경우가 생길 것 같습니다. (애매한 파일 경계)

- 분리하지 않을  경우, 하나의 map과 하나의 사용 방식( &lt;SVGIcon /&gt; ) 으로 빠르고 간단하게 쓸 수 있다는 장점이 있습니다.
다만, SVGIcon의 책임이 커져 size와 viewBox에서 문제가 생길 가능성이 있습니다.
